### PR TITLE
[#38 ] fix:회원탈퇴 버그 수정

### DIFF
--- a/src/main/java/com/example/springrider/config/filter/SessionLoginCheckFilter.java
+++ b/src/main/java/com/example/springrider/config/filter/SessionLoginCheckFilter.java
@@ -27,7 +27,8 @@ public class SessionLoginCheckFilter implements Filter {
         // 로그인 없이 접근 가능한 경로
         if (uri.startsWith("/api/users/login") ||
             uri.startsWith("/api/users/signup") ||
-            uri.startsWith("/api/users/logout")) {
+            uri.startsWith("/api/users/logout") ||
+            uri.startsWith("/api/users/withdraw")) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/example/springrider/domain/common/exception/ExceptionCode.java
+++ b/src/main/java/com/example/springrider/domain/common/exception/ExceptionCode.java
@@ -11,12 +11,14 @@ public enum ExceptionCode {
     AUTH_EXCEPTION("인증인가 예외 메세지"),
     PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다."),
     ALREADY_LOGGED_IN("이미 로그인된 상태입니다."),
+    UNAUTHORIZED("로그인 후 이용 가능합니다."),
 
     // 회원
     USER_EXCEPTION("회원 예외 메세지"),
     EMAIL_ALREADY_USED("이미 사용 중인 이메일입니다."),
     EMAIL_NOT_FOUND("이메일이 존재하지 않습니다."),
     USER_NOT_FOUND("임시로 만든 유저낫빠운드~"),
+    ALREADY_DELETED_USER("이미 탈퇴한 회원입니다."),
 
     // 가게
     STORE_NOT_FOUND("존재하지 않는 가게입니다."), // 존재하지 않는 가게 조회 시

--- a/src/main/java/com/example/springrider/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/springrider/domain/user/controller/UserController.java
@@ -48,7 +48,7 @@ public class UserController {
         HttpSession session
     ) {
         if (userId == null) {
-            throw new AuthException(ExceptionCode.AUTH_EXCEPTION);
+            throw new AuthException(ExceptionCode.UNAUTHORIZED);
         }
 
         userService.withdraw(requestDto, userId, session);
@@ -61,7 +61,7 @@ public class UserController {
         @SessionAttribute(name = "userId", required = false) Long userId
     ) {
         if (userId == null) {
-            throw new AuthException(ExceptionCode.AUTH_EXCEPTION);
+            throw new AuthException(ExceptionCode.UNAUTHORIZED);
         }
 
         userService.modifyPassword(requestDto, userId);

--- a/src/main/java/com/example/springrider/domain/user/entity/User.java
+++ b/src/main/java/com/example/springrider/domain/user/entity/User.java
@@ -47,5 +47,8 @@ public class User extends BaseEntity {
         this.password = newPassword;
     }
 
+    public void withdraw() {
+        this.isWithdraw = true;
+    }
 
 }

--- a/src/main/java/com/example/springrider/domain/user/service/UserService.java
+++ b/src/main/java/com/example/springrider/domain/user/service/UserService.java
@@ -55,6 +55,11 @@ public class UserService {
         }
 
         User user = userRepository.findByEmailOrElseThrow(requestDto.getEmail());
+
+        if (user.getIsWithdraw()) {
+            throw new AuthException(ExceptionCode.ALREADY_DELETED_USER);
+        }
+
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
             throw new AuthException(ExceptionCode.PASSWORD_NOT_MATCH);
         }
@@ -67,18 +72,33 @@ public class UserService {
 
     // 회원 탈퇴
     public void withdraw(DeleteUserRequestDto requestDto, Long userId, HttpSession session) {
+
+        if (userId == null) {
+            throw new AuthException(ExceptionCode.UNAUTHORIZED);
+        }
+
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new AuthException(ExceptionCode.USER_NOT_FOUND));
 
+        // 탈퇴 상태 체크
+        if (user.getIsWithdraw()) {
+            throw new AuthException(ExceptionCode.ALREADY_DELETED_USER);
+        }
+
+        // 이메일 일치 체크
         if (!user.getEmail().equals(requestDto.getEmail())) {
             throw new AuthException(ExceptionCode.EMAIL_NOT_FOUND);
         }
 
+        // 비밀번호 일치 체크
         if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
             throw new AuthException(ExceptionCode.PASSWORD_NOT_MATCH);
         }
 
-        userRepository.delete(user); // 하드 딜리트 방식
+        user.withdraw(); // 소프트 딜리트
+
+        userRepository.save(user);
+
         session.invalidate();
     }
 


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [X] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- fix/user-auth-bugs -> dev

## 💡 구현 내용 요약
- 회원탈퇴가 완료된 후 다시 한 번 회원탈퇴 요청을 보내면 해당 가게에 접근 권한이 없습니다 라고 발생하던것을 "로그인 후 이용 가능합니다." 로 수정

## ✅ 체크리스트
- [X] 코드 컨벤션을 지켰나요?
- [X] 로직 테스트를 완료했나요?
- [X] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: #38 

## 📝 기타 참고 사항
