### PR TITLE
[#48] fix: 주문 생성 시 가게 정보 조회되지 않는 현상 수정

### DIFF
--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -11,7 +11,6 @@ import com.example.springrider.domain.order.entity.OrderItem;
 import com.example.springrider.domain.order.enums.OrderStatus;
 import com.example.springrider.domain.order.repository.OrderRepository;
 import com.example.springrider.domain.store.entity.Store;
-import com.example.springrider.domain.store.repository.StoreRepository;
 import com.example.springrider.domain.user.entity.User;
 import com.example.springrider.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -28,7 +27,6 @@ public class UserOrderService {
     private final OrderRepository orderRepository;
     private final CartRepository cartRepository;
     private final UserRepository userRepository;
-    private final StoreRepository storeRepository;
 
     /**
      * 주문 요청 서비스

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -48,8 +48,7 @@ public class UserOrderService {
 
         // 2. 사용자와 가게 정보 조회
         User user = userRepository.findByIdOrElseThrow(userId);
-        Long storeId = cartItems.get(0).getStoreId();
-        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        Store store = cartItems.get(0).getMenu().getStore();
 
         // 3. 주문 생성
         Order order = new Order();


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- feat/order → dev

## 💡 구현 내용 요약
- 영속성 컨텍스트가 초기화되지 않아서 DB에 접근했을 때 `null` 로 가져온답니다 - GPT

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [ ] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: closes #48 

## 📝 기타 참고 사항
<img width="801" alt="image" src="https://github.com/user-attachments/assets/d302c1e6-13a8-40cb-8dbb-2b56ccc9b846" />
