### PR TITLE
[#76] test: 가게 생성 시 3개를 초과하면 예외

### DIFF
--- a/src/test/java/com/example/springrider/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/springrider/domain/store/service/StoreServiceTest.java
@@ -1,12 +1,14 @@
 package com.example.springrider.domain.store.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.example.springrider.domain.common.exception.InvalidRequestException;
 import com.example.springrider.domain.store.dto.StoreRequestDto;
 import com.example.springrider.domain.store.dto.StoreResponseDto;
 import com.example.springrider.domain.store.entity.Store;
@@ -94,5 +96,24 @@ class StoreServiceTest {
         // then
         assertNotNull(responseDto);
         verify(storeRepository, times(1)).save(any(Store.class));
+    }
+
+    @Test
+    void create_store_가게_생성_시_3개가_초과하면_예외_처리() {
+        when(userRepository.findByIdOrElseThrow(anyLong())).thenReturn(mockUser);
+        when(storeRepository.countByUser(mockUser)).thenReturn(3L);
+
+        StoreRequestDto requestDto = new StoreRequestDto(
+            "맛집", "서울", "한식",
+            LocalTime.of(10, 0),
+            LocalTime.of(20, 0),
+            10000,
+            StoreStatus.ACTIVE,
+            1L
+        );
+
+        assertThrows(InvalidRequestException.class, () -> {
+            storeService.create(requestDto, 1L);
+        });
     }
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- test/store-create -> dev

## 💡 구현 내용 요약
- 가게 생성 시 3개를 초과하면 예외

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [x] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: #76 

## 📝 기타 참고 사항
- 이슈 100까지 슈웃~!@
