### PR TITLE
[#48] feat: 주문 생성 시 AOP에 의한 로깅 추가

### DIFF
--- a/src/main/java/com/example/springrider/aop/OrderEventLog.java
+++ b/src/main/java/com/example/springrider/aop/OrderEventLog.java
@@ -1,0 +1,12 @@
+package com.example.springrider.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface OrderEventLog {
+
+}

--- a/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
+++ b/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
@@ -1,0 +1,41 @@
+package com.example.springrider.aop;
+
+import com.example.springrider.domain.common.exception.ExceptionCode;
+import com.example.springrider.domain.common.exception.InvalidRequestException;
+import com.example.springrider.domain.order.dto.CreateOrderResponseDto;
+import com.example.springrider.domain.order.repository.OrderRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class OrderEventLogAspect {
+
+    private final OrderRepository orderRepository;
+
+    @Around("@annotation(OrderEventLog)")
+    public Object logOrderCreate(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        LocalDateTime requestTime = LocalDateTime.now();
+        Object result = joinPoint.proceed();
+
+        if (result instanceof CreateOrderResponseDto responseDto) {
+            Long orderId = responseDto.getOrderId();
+            Long storeId = orderRepository.findById(orderId)
+                .map(order -> order.getStore().getId())
+                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.STORE_NOT_FOUND));
+
+            log.info("[주문 생성] 시간={}, 가게번호={}, 주문번호={}", requestTime, storeId, orderId);
+        }
+
+        return result;
+    }
+
+}

--- a/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
+++ b/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
@@ -1,9 +1,7 @@
 package com.example.springrider.aop;
 
-import com.example.springrider.domain.common.exception.ExceptionCode;
-import com.example.springrider.domain.common.exception.InvalidRequestException;
 import com.example.springrider.domain.order.dto.CreateOrderResponseDto;
-import com.example.springrider.domain.order.repository.OrderRepository;
+import com.example.springrider.domain.order.service.UserOrderService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,7 +16,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OrderEventLogAspect {
 
-    private final OrderRepository orderRepository;
+    private final UserOrderService userOrderService;
 
     @Around("@annotation(OrderEventLog)")
     public Object logOrderCreate(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -28,9 +26,7 @@ public class OrderEventLogAspect {
 
         if (result instanceof CreateOrderResponseDto responseDto) {
             Long orderId = responseDto.getOrderId();
-            Long storeId = orderRepository.findById(orderId)
-                .map(order -> order.getStore().getId())
-                .orElseThrow(() -> new InvalidRequestException(ExceptionCode.STORE_NOT_FOUND));
+            Long storeId = userOrderService.findStoreIdFromOrder(orderId);
 
             log.info("[주문 생성] 시간={}, 가게번호={}, 주문번호={}", requestTime, storeId, orderId);
         }

--- a/src/main/java/com/example/springrider/aop/StoreOwnerCheckAspect.java
+++ b/src/main/java/com/example/springrider/aop/StoreOwnerCheckAspect.java
@@ -3,7 +3,7 @@ package com.example.springrider.aop;
 import com.example.springrider.domain.common.exception.AuthException;
 import com.example.springrider.domain.common.exception.ExceptionCode;
 import com.example.springrider.domain.store.entity.Store;
-import com.example.springrider.domain.store.repository.StoreRepository;
+import com.example.springrider.domain.store.service.StoreService;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.JoinPoint;
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class StoreOwnerCheckAspect {
 
-    private final StoreRepository storeRepository;
+    private final StoreService storeService;
 
     @Before("@annotation(storeOwnerCheck)")
     public void checkStoreOwner(JoinPoint joinPoint, StoreOwnerCheck storeOwnerCheck) {
@@ -41,7 +41,7 @@ public class StoreOwnerCheckAspect {
             throw new IllegalArgumentException("userId 나 storeId를 찾을 수 없습니다.");
         }
 
-        Store store = storeRepository.findByIdOrElseThrow(storeId);
+        Store store = storeService.findEntity(storeId);
         if (!Objects.equals(store.getUser().getId(), userId)) {
             throw new AuthException(ExceptionCode.STORE_ACCESS_DENIED);
         }

--- a/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
@@ -1,5 +1,7 @@
 package com.example.springrider.domain.order.repository;
 
+import com.example.springrider.domain.common.exception.ExceptionCode;
+import com.example.springrider.domain.common.exception.InvalidRequestException;
 import com.example.springrider.domain.order.entity.Order;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,5 +17,10 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
         WHERE o.id = :orderId
         """)
     Optional<Order> findByIdWithOrderItemsAndMenu(@Param("orderId") Long orderId);
+
+    default Order findByIdOrElseThrow(Long orderId) {
+        return findById(orderId)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ORDER_NOT_FOUND));
+    }
 
 }

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -1,5 +1,6 @@
 package com.example.springrider.domain.order.service;
 
+import com.example.springrider.aop.OrderEventLog;
 import com.example.springrider.domain.cart.entity.CartItem;
 import com.example.springrider.domain.cart.repository.CartRepository;
 import com.example.springrider.domain.common.exception.ExceptionCode;
@@ -33,6 +34,7 @@ public class UserOrderService {
      * @param userId     유저 식별자
      * @return 생성된 주문 정보가 담긴 {@link CreateOrderResponseDto}
      */
+    @OrderEventLog
     public CreateOrderResponseDto create(CreateOrderRequestDto requestDto, Long userId) {
         // 1. 장바구니 메뉴 조회
         List<CartItem> cartItems = cartRepository.findAllByUserIdAndModifiedAtAfterWithMenuAndStore(

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -81,4 +81,10 @@ public class UserOrderService {
 
     }
 
+    public Long findStoreIdFromOrder(Long orderId) {
+        return orderRepository.findById(orderId)
+            .map(order -> order.getStore().getId())
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.STORE_NOT_FOUND));
+    }
+
 }

--- a/src/main/java/com/example/springrider/domain/store/service/StoreService.java
+++ b/src/main/java/com/example/springrider/domain/store/service/StoreService.java
@@ -145,4 +145,15 @@ public class StoreService {
         // 가게의 정보와 메뉴도 보이게 가게 상세 dto 형태 반환
         return FindStoreResponseDto.from(store);
     }
+
+    /**
+     * {@link Store} 엔티티 반환 메소드
+     *
+     * @param storeId 가게 식별자
+     * @return {@link Store}
+     */
+    public Store findEntity(Long storeId) {
+        return storeRepository.findByIdOrElseThrow(storeId);
+    }
+
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- feat/order-request-aop

## 💡 구현 내용 요약
- 주문 생성 시 AOP에 의한 로깅 구현
- 주문 시각, 주문 아이디, 가게 아이디 출력

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [ ] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: #48 

## 📝 기타 참고 사항
- 
