### PR TITLE
[#49] 유저 주문 목록 조회 API

### DIFF
--- a/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
+++ b/src/main/java/com/example/springrider/aop/OrderEventLogAspect.java
@@ -1,6 +1,6 @@
 package com.example.springrider.aop;
 
-import com.example.springrider.domain.order.dto.CreateOrderResponseDto;
+import com.example.springrider.domain.order.dto.OrderResponseDto;
 import com.example.springrider.domain.order.service.UserOrderService;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ public class OrderEventLogAspect {
         LocalDateTime requestTime = LocalDateTime.now();
         Object result = joinPoint.proceed();
 
-        if (result instanceof CreateOrderResponseDto responseDto) {
+        if (result instanceof OrderResponseDto responseDto) {
             Long orderId = responseDto.getOrderId();
             Long storeId = userOrderService.findStoreIdFromOrder(orderId);
 

--- a/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
+++ b/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
@@ -2,7 +2,7 @@ package com.example.springrider.domain.order.controller;
 
 import com.example.springrider.domain.common.response.ApiResponse;
 import com.example.springrider.domain.order.dto.CreateOrderRequestDto;
-import com.example.springrider.domain.order.dto.CreateOrderResponseDto;
+import com.example.springrider.domain.order.dto.OrderResponseDto;
 import com.example.springrider.domain.order.service.UserOrderService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -22,10 +22,10 @@ public class UserOrderController {
      * 주문 생성 요청 컨트롤러
      *
      * @param requestDto 주문 정보가 담긴 {@link CreateOrderRequestDto}
-     * @return 생성된 주문 정보가 담긴 {@link CreateOrderResponseDto}
+     * @return 생성된 주문 정보가 담긴 {@link OrderResponseDto}
      */
     @PostMapping
-    public ApiResponse<CreateOrderResponseDto> create(
+    public ApiResponse<OrderResponseDto> create(
         @RequestBody CreateOrderRequestDto requestDto,
         @SessionAttribute(name = "userId") Long userId
     ) {

--- a/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
+++ b/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
@@ -4,6 +4,7 @@ import com.example.springrider.domain.common.response.ApiResponse;
 import com.example.springrider.domain.order.dto.CreateOrderRequestDto;
 import com.example.springrider.domain.order.dto.OrderResponseDto;
 import com.example.springrider.domain.order.service.UserOrderService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,7 +41,8 @@ public class UserOrderController {
      * @return 고객이 주문한 목록 정보가 담긴 {@link OrderResponseDto}
      */
     @GetMapping
-    public ApiResponse<OrderResponseDto> findAll(@SessionAttribute(name = "userId") Long userId) {
+    public ApiResponse<List<OrderResponseDto>> findAll(
+        @SessionAttribute(name = "userId") Long userId) {
         return ApiResponse.ok(userOrderService.findAll(userId));
     }
 

--- a/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
+++ b/src/main/java/com/example/springrider/domain/order/controller/UserOrderController.java
@@ -5,6 +5,7 @@ import com.example.springrider.domain.order.dto.CreateOrderRequestDto;
 import com.example.springrider.domain.order.dto.OrderResponseDto;
 import com.example.springrider.domain.order.service.UserOrderService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,6 +31,17 @@ public class UserOrderController {
         @SessionAttribute(name = "userId") Long userId
     ) {
         return ApiResponse.created(userOrderService.create(requestDto, userId));
+    }
+
+    /**
+     * 주문 목록 조회 요청 컨트롤러
+     *
+     * @param userId 유저 식별자
+     * @return 고객이 주문한 목록 정보가 담긴 {@link OrderResponseDto}
+     */
+    @GetMapping
+    public ApiResponse<OrderResponseDto> findAll(@SessionAttribute(name = "userId") Long userId) {
+        return ApiResponse.ok(userOrderService.findAll(userId));
     }
 
 }

--- a/src/main/java/com/example/springrider/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/example/springrider/domain/order/dto/OrderResponseDto.java
@@ -7,14 +7,14 @@ import lombok.RequiredArgsConstructor;
 
 @Getter
 @RequiredArgsConstructor
-public class CreateOrderResponseDto {
+public class OrderResponseDto {
 
     private final Long orderId;
     private final String storeName;
     private final List<OrderItemDto> item;
 
-    public static CreateOrderResponseDto of(Order order) {
-        return new CreateOrderResponseDto(
+    public static OrderResponseDto of(Order order) {
+        return new OrderResponseDto(
             order.getId(),
             order.getStore().getName(),
             order.getOrderItems().stream()

--- a/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
@@ -23,4 +23,11 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
             .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ORDER_NOT_FOUND));
     }
 
+    @Query("""
+        SELECT DISTINCT o FROM Order o
+        JOIN FETCH o.orderItems oi
+        WHERE o.id = :userId
+        """)
+    Optional<Order> findByUserIdWithOrderItemsAndMenu(@Param("userId") Long userId);
+
 }

--- a/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/springrider/domain/order/repository/OrderRepository.java
@@ -3,6 +3,7 @@ package com.example.springrider.domain.order.repository;
 import com.example.springrider.domain.common.exception.ExceptionCode;
 import com.example.springrider.domain.common.exception.InvalidRequestException;
 import com.example.springrider.domain.order.entity.Order;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -24,10 +25,12 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     }
 
     @Query("""
-        SELECT DISTINCT o FROM Order o
+        SELECT o FROM Order o
         JOIN FETCH o.orderItems oi
-        WHERE o.id = :userId
+        JOIN FETCH oi.menu m
+        JOIN FETCH o.store s
+        WHERE o.user.id = :userId
         """)
-    Optional<Order> findByUserIdWithOrderItemsAndMenu(@Param("userId") Long userId);
+    List<Order> findAllByUserIdWithOrderItemsAndMenuAndStore(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -87,9 +87,11 @@ public class UserOrderService {
      * @param userId 유저 식별자
      * @return 주문 목록 정보가 담긴 {@link OrderResponseDto}
      */
-    public OrderResponseDto findAll(Long userId) {
-        return OrderResponseDto.of(orderRepository.findByUserIdWithOrderItemsAndMenu(userId)
-            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ORDER_NOT_FOUND)));
+    public List<OrderResponseDto> findAll(Long userId) {
+        List<Order> orders = orderRepository.findAllByUserIdWithOrderItemsAndMenuAndStore(userId);
+        return orders.stream()
+            .map(OrderResponseDto::of)
+            .toList();
     }
 
     public Long findStoreIdFromOrder(Long orderId) {

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -81,6 +81,17 @@ public class UserOrderService {
 
     }
 
+    /**
+     * 주문 목록 조회 서비스
+     *
+     * @param userId 유저 식별자
+     * @return 주문 목록 정보가 담긴 {@link OrderResponseDto}
+     */
+    public OrderResponseDto findAll(Long userId) {
+        return OrderResponseDto.of(orderRepository.findByUserIdWithOrderItemsAndMenu(userId)
+            .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ORDER_NOT_FOUND)));
+    }
+
     public Long findStoreIdFromOrder(Long orderId) {
         return orderRepository.findById(orderId)
             .map(order -> order.getStore().getId())

--- a/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
+++ b/src/main/java/com/example/springrider/domain/order/service/UserOrderService.java
@@ -6,7 +6,7 @@ import com.example.springrider.domain.cart.repository.CartRepository;
 import com.example.springrider.domain.common.exception.ExceptionCode;
 import com.example.springrider.domain.common.exception.InvalidRequestException;
 import com.example.springrider.domain.order.dto.CreateOrderRequestDto;
-import com.example.springrider.domain.order.dto.CreateOrderResponseDto;
+import com.example.springrider.domain.order.dto.OrderResponseDto;
 import com.example.springrider.domain.order.entity.Order;
 import com.example.springrider.domain.order.entity.OrderItem;
 import com.example.springrider.domain.order.enums.OrderStatus;
@@ -32,10 +32,10 @@ public class UserOrderService {
      *
      * @param requestDto 배달 주소 정보가 담긴 {@link CreateOrderRequestDto}
      * @param userId     유저 식별자
-     * @return 생성된 주문 정보가 담긴 {@link CreateOrderResponseDto}
+     * @return 생성된 주문 정보가 담긴 {@link OrderResponseDto}
      */
     @OrderEventLog
-    public CreateOrderResponseDto create(CreateOrderRequestDto requestDto, Long userId) {
+    public OrderResponseDto create(CreateOrderRequestDto requestDto, Long userId) {
         // 1. 장바구니 메뉴 조회
         List<CartItem> cartItems = cartRepository.findAllByUserIdAndModifiedAtAfterWithMenuAndStore(
             userId, LocalDateTime.now().minusDays(1)
@@ -77,7 +77,7 @@ public class UserOrderService {
         Order orderWithItems = orderRepository.findByIdWithOrderItemsAndMenu(savedOrder.getId())
             .orElseThrow(() -> new InvalidRequestException(ExceptionCode.ORDER_NOT_FOUND));
 
-        return CreateOrderResponseDto.of(orderWithItems);
+        return OrderResponseDto.of(orderWithItems);
 
     }
 


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- feat/order-get-list → dev

## 💡 구현 내용 요약
- 주문 목록 테이블에서 로그인한 유저의 주문 목록을 가져오는 기능 구현

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [ ] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: Closes #49 

## 📝 기타 참고 사항
- 
