### PR TITLE
[#89] test: 전체 가게 조회 성공 테스트

### DIFF
--- a/src/test/java/com/example/springrider/domain/store/service/StoreServiceTest.java
+++ b/src/test/java/com/example/springrider/domain/store/service/StoreServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.example.springrider.domain.common.exception.InvalidRequestException;
+import com.example.springrider.domain.store.dto.FindStoresResponseDto;
 import com.example.springrider.domain.store.dto.StoreRequestDto;
 import com.example.springrider.domain.store.dto.StoreResponseDto;
 import com.example.springrider.domain.store.dto.UpdateStoreRequestDto;
@@ -21,6 +22,9 @@ import com.example.springrider.domain.user.enums.UserRole;
 import com.example.springrider.domain.user.repository.UserRepository;
 import java.lang.reflect.Field;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -181,5 +185,27 @@ class StoreServiceTest {
         assertThrows(InvalidRequestException.class, () -> {
             storeService.update(1L, dto, 2L);
         });
+    }
+
+    @Test
+    void finds_전체_가게_조회에_성공한다() {
+        // given 가게 6개를 만들고 반환할 준비
+        // 가게0, 가게1, 가게2, 가게3 ...
+        List<Store> dummyStores = IntStream.range(0, 6)
+            .mapToObj(i -> Store.StoreInfo(
+                new StoreRequestDto("가게" + i, "서울", "한식",
+                    LocalTime.of(9, 0), LocalTime.of(22, 0), 10000,
+                    StoreStatus.ACTIVE, 1L
+                ), mockUser))
+            .collect(Collectors.toList());
+
+        // store 레포지토리가 findAllByStatusNot(StoreStatus.CLOSED)를 호출하면 위에서 만든 가게 6개를 반환
+        when(storeRepository.findAllByStatusNot(StoreStatus.CLOSED)).thenReturn(dummyStores);
+
+        // when finds 메소드 호출
+        List<FindStoresResponseDto> stores = storeService.finds();
+
+        // then 그럼 stores리스트 크기가 6인지 홧ㄱ인
+        assertEquals(6, stores.size());
     }
 }


### PR DESCRIPTION
## PR 타입 (하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
- test/get-all-stores -> dev

## 💡 구현 내용 요약
- 전체 가게가 6개가 생성됐을 때를 가정해서 전체 가게 조회 기능 테스트 코드 만들어 통과했습니다

## ✅ 체크리스트
- [x] 코드 컨벤션을 지켰나요?
- [x] 로직 테스트를 완료했나요?
- [x] 문서 수정이 필요한가요?

## 🔍 관련 이슈
- 관련 이슈 번호: #89 

## 📝 기타 참고 사항
- 빠이링
